### PR TITLE
fix train in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -283,7 +283,7 @@ def train(loader, model, crit, opt, epoch):
                   .format(epoch, i, len(loader), batch_time=batch_time,
                           data_time=data_time, loss=losses))
 
-        return losses.avg
+    return losses.avg
 
 def compute_features(dataloader, model, N):
     if args.verbose:


### PR DESCRIPTION
In main.py, `return losses.avg` is in `for` loop of training, so the training in each epoch is done with only first one mini-batch of dataloader. This PR locates `return` after the `for` loop.